### PR TITLE
Add namespace to android

### DIFF
--- a/packages/wasm_run_flutter/android/build.gradle
+++ b/packages/wasm_run_flutter/android/build.gradle
@@ -29,6 +29,8 @@ android {
     // to bump the version in their app.
     compileSdkVersion 31
 
+    namespace 'com.example.wasm_run_flutter'
+
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.
     ndkVersion "21.4.7075529"


### PR DESCRIPTION
Fixes compile error with gradle 8.

To test this add this to pubspec.yaml:
```
  wasm_run_flutter: #^0.1.0
    git:
      url: https://github.com/Hedon-dev/wasm_run
      ref: 69a7426
      path: packages/wasm_run_flutter
```