### PR TITLE
Fixed disposing of an instance

### DIFF
--- a/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_native.dart
+++ b/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_native.dart
@@ -712,7 +712,7 @@ class _Instance extends WasmInstance {
 
   @override
   void dispose() {
-    // TODO: dispose
+    builder.mod.dispose();
   }
 }
 


### PR DESCRIPTION
Instances never dispose properly, causing a memory leak. Once you create an instance you cannot dispose it